### PR TITLE
Set the items content to summary if content is unavailable and summar…

### DIFF
--- a/app/src/main/java/com/indieweb/indigenous/microsub/timeline/TimelineActivity.java
+++ b/app/src/main/java/com/indieweb/indigenous/microsub/timeline/TimelineActivity.java
@@ -329,6 +329,8 @@ public class TimelineActivity extends AppCompatActivity implements SwipeRefreshL
                                         catch (Exception ignored) {}
                                     }
 
+                                } else if(object.has("summary")) {
+                                    textContent = object.getString("summary");
                                 }
 
                                 // Name.


### PR DESCRIPTION
When content does not exist in the microsub response and summary does, use summary.

This PR sidesteps https://github.com/aaronpk/Aperture/issues/56

Makes this:
![screenshot_20180824-115532](https://user-images.githubusercontent.com/382760/44567396-cb2d0300-a7a4-11e8-95b7-d9297806d3a2.png)

Be this:
![hevent](https://user-images.githubusercontent.com/382760/44567455-09c2bd80-a7a5-11e8-8efe-dcf86a699dd3.png)
