### PR TITLE
Add shameless Kittybox self-promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,5 @@ https://github.com/EdwardHinkle/indigenous-ios
 
 ## Other clients
 
-https://github.com/pstuifzand/micropub-android
+- https://github.com/pstuifzand/micropub-android
+- https://gitlab.com/vikanezrimaya/kittybox-android (in development)


### PR DESCRIPTION
I develop a Micropub/Microsub client named Kittybox and I think users should be aware that there might be another choice in the future... isn't the IndieWeb philosophy all about choice?