### PR TITLE
Fix GPX file picker on Android 13+ and transport selection bug

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="trip_load_gpx">Load GPX file</string>
     <string name="trip_reading_error">Error reading GPX file: %s</string>
     <string name="trip_no_points_found">No points found in GPX file.</string>
+    <string name="trip_invalid_file_type">Please select a GPX file (.gpx)</string>
     <string name="location_start">Start location</string>
     <string name="location_end">End location</string>
     <string name="transport">Transport</string>


### PR DESCRIPTION
## Summary

- Fix GPX file selection on Android 13+ by using `ACTION_OPEN_DOCUMENT` without restrictive MIME type filters
- Add file extension validation to ensure only `.gpx` files are accepted
- Fix transport spinner bug that was causing errors when selecting a transport mode

## Problem

On Android 13+, GPX files were visible in the file picker but could not be selected. This was because:
1. The previous implementation used `Intent.createChooser()` which interferes with the Storage Access Framework
2. GPX files may have various MIME types (`application/gpx+xml`, `application/octet-stream`, `text/xml`, etc.) that didn't match the filter

Additionally, selecting a transport mode (Boat, Walk, etc.) caused an error due to a typo using `read.getSelectedItemPosition()` instead of `transport.getSelectedItemPosition()`.

## Changes

- Use `ACTION_OPEN_DOCUMENT` with `CATEGORY_OPENABLE` and proper permission flags
- Remove MIME type restrictions (GPX files have inconsistent MIME types across devices)
- Add `isGpxFile()` method to validate file extension after selection
- Add `trip_invalid_file_type` string resource for user-friendly error message
- Fix transport spinner variable name typo

## Test plan

- [ ] Create a Trip post on Android 13+ device
- [ ] Tap "Load GPX" and verify GPX files are selectable
- [ ] Verify non-GPX files show "Please select a GPX file (.gpx)" error
- [ ] Select a transport mode and verify the Trip posts successfully